### PR TITLE
FallingText: mobile font-size/line-height at ≤767px

### DIFF
--- a/src/FallingText.css
+++ b/src/FallingText.css
@@ -38,4 +38,11 @@
     left: 0;
     z-index: 0;
   }
-  
+
+
+@media (max-width:767px) {
+    .falling-text-target {
+    font-size: 20px !important;
+    line-height: 20px !important;
+}
+}


### PR DESCRIPTION
Adds a media query for .falling-text-target – font-size: 20px; line-height: 20px – to prevent overlap on small screens.